### PR TITLE
Check protocol before setting default port in http.request

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var EventEmitter = require('events').EventEmitter
 var Request = require('./lib/request')
 var url = require('url')
 var defaults = {
-    port: 80,
+    port: (protocol) => protocol == 'https:' ? 443 : 80,
     protocol: 'http:'
 }
 
@@ -17,8 +17,7 @@ http.request = function (params, cb) {
     }
     if (!params) params = {}
     if (!params.host && !params.port) {
-        if (params.protocol === 'https:') params.port = 443
-        else params.port = defaults.port
+         params.port = defaults.port(params.protocol)
     }
     if (!params.host && params.hostname) {
         params.host = params.hostname
@@ -42,7 +41,7 @@ http.request = function (params, cb) {
         }
         params.host = params.host.split(':')[0]
     }
-    if (!params.port) params.port = params.protocol == 'https:' ? 443 : 80
+    if (!params.port) params.port = defaults.port(params.protocol)
 
     var req = new Request(new XMLHttpRequest(), params)
     if (cb) req.on('response', cb)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ http.request = function (params, cb) {
     }
     if (!params) params = {}
     if (!params.host && !params.port) {
-        params.port = defaults.port
+        if (params.protocol === 'https:') params.port = 443
+        else params.port = defaults.port
     }
     if (!params.host && params.hostname) {
         params.host = params.hostname


### PR DESCRIPTION
**Problem**

If a user creates a request object that has the hostname and not the port or host, http.request will set the port to 80. If the request was a https url, then the request will error.

This could be a common issue since many string to url object parsers omit the port number.

**Solution**

http.request should check the protocol value before setting the default port value.

**Note**
The more elegant way to solve this would be the move the conditional for setting params.host = params.hostname before the conditional setting the default port, but I wasn't sure if there was a reason for this order.